### PR TITLE
Feature/unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
-project(pdftms CXX)
 
 set(CMAKE_CXX_COMPILER g++)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENTIONS OFF)
+
+project(pdftms CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic")
@@ -21,3 +22,5 @@ target_link_libraries(${PROJECT_NAME}
     PRIVATE
     yaml-cpp
 )
+
+add_subdirectory(tests)

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,15 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.mkShell {
-    buildInputs = [
-        pkgs.cmake
-        pkgs.gnumake
-        pkgs.gcc
+  buildInputs = [
+    pkgs.cmake
+    pkgs.gnumake
+    pkgs.gcc
+    pkgs.gtest
 
-        pkgs.fzf
-        pkgs.yaml-cpp
-    ];
+    pkgs.fzf
+    pkgs.yaml-cpp
+  ];
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,12 +1,10 @@
 #include "utils.hpp"
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <array>
 #include <optional>
 #include <unistd.h>
-#include <filesystem>
 
 std::string expand_tilde(const std::string& path) {
     if (!path.empty() && path[0] == '~') {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic")
+
+include_directories(include)
+
+find_package(GTest REQUIRED)
+
+add_executable(pdftms_tests
+    test_utils.cpp
+    test_config.cpp
+)
+
+target_include_directories(pdftms_tests
+
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(pdftms_tests
+    PRIVATE
+        yaml-cpp
+        GTest::GTest
+        GTest::Main
+)
+
+target_sources(pdftms_tests
+
+    PRIVATE 
+        ${CMAKE_SOURCE_DIR}/src/commands.cpp
+        ${CMAKE_SOURCE_DIR}/src/config.cpp
+        ${CMAKE_SOURCE_DIR}/src/utils.cpp
+        ${CMAKE_SOURCE_DIR}/src/fs.cpp
+)
+
+enable_testing()
+add_test(
+    NAME pdftms_tests
+    COMMAND pdftms_tests
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(GTest REQUIRED)
 add_executable(pdftms_tests
     test_utils.cpp
     test_config.cpp
+    test_fs.cpp
 )
 
 target_include_directories(pdftms_tests

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+#include "config.hpp"
+#include <filesystem>
+#include <fstream>
+
+class ConfigTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        original_home = std::getenv("HOME");
+
+        test_home_ = std::filesystem::temp_directory_path() / "pdftms_test_home";
+        std::filesystem::create_directories(test_home_);
+        setenv("HOME", test_home_.c_str(), 1);
+
+        config_dir_ = test_home_ / ".config";
+        std::filesystem::create_directories(config_dir_);
+
+        test_config.base_dir_path = "/test/documents";
+        test_config.pdf_viewer = "test-viewer";
+    }
+
+    void TearDown() override {
+        if (original_home) {
+            setenv("HOME", original_home, 1);
+        } else {
+            unsetenv("HOME");
+        }
+
+        std::filesystem::remove_all(test_home_);
+    }
+
+    const char* original_home;
+    std::filesystem::path test_home_;
+    std::filesystem::path config_dir_;
+    Config test_config;
+
+    void write_yaml_to_file(const std::string& path, const std::string& content) {
+        std::ofstream file(path);
+        file << content;
+    }
+
+    std::string read_file(const std::string& path) {
+        std::ifstream file(path);
+        return std::string(std::istreambuf_iterator<char>(file),
+                          std::istreambuf_iterator<char>());
+    }
+};
+
+TEST_F(ConfigTest, YamlEncode) {
+    YAML::Node node = YAML::convert<Config>::encode(test_config);
+
+    EXPECT_EQ(node["base_dir_path"].as<std::string>(), "/test/documents");
+    EXPECT_EQ(node["pdf_viewer"].as<std::string>(), "test-viewer");
+}
+
+TEST_F(ConfigTest, YamlDecode) {
+    YAML::Node node;
+    node["base_dir_path"] = "/test/documents";
+    node["pdf_viewer"] = "test-viewer";
+
+    Config config;
+    bool result = YAML::convert<Config>::decode(node, config);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(config.base_dir_path, "/test/documents");
+    EXPECT_EQ(config.pdf_viewer, "test-viewer");
+}
+
+TEST_F(ConfigTest, YamlDecodeInvalidNode) {
+    YAML::Node node = YAML::Load("- invalid\n- sequence");
+    Config config;
+
+    bool result = YAML::convert<Config>::decode(node, config);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(ConfigTest, CreateConfig) {
+    create_config(test_config);
+
+    std::filesystem::path config_path = config_dir_ / "pdftms.yaml";
+    ASSERT_TRUE(std::filesystem::exists(config_path));
+
+    std::string content = read_file(config_path);
+    YAML::Node node = YAML::Load(content);
+
+    EXPECT_EQ(node["base_dir_path"].as<std::string>(), "/test/documents");
+    EXPECT_EQ(node["pdf_viewer"].as<std::string>(), "test-viewer");
+}
+
+TEST_F(ConfigTest, ReadConfig) {
+    std::string yaml_content = 
+        "base_dir_path: /test/documents\n"
+        "pdf_viewer: test-viewer\n";
+
+    std::filesystem::path config_path = config_dir_ / "test_config.yaml";
+    write_yaml_to_file(config_path, yaml_content);
+
+    Config config = read_config(config_path);
+
+    EXPECT_EQ(config.base_dir_path, "/test/documents");
+    EXPECT_EQ(config.pdf_viewer, "test-viewer");
+}
+
+TEST_F(ConfigTest, ReadNonExistentConfig) {
+    std::filesystem::path non_existent_path = config_dir_ / "nonexistent.yaml";
+
+    EXPECT_THROW(read_config(non_existent_path), YAML::BadFile);
+}
+
+TEST_F(ConfigTest, ReadInvalidConfig) {
+    std::string invalid_yaml = "invalid: yaml: content: - [";
+    std::filesystem::path invalid_config_path = config_dir_ / "invalid.yaml";
+    write_yaml_to_file(invalid_config_path, invalid_yaml);
+
+    EXPECT_THROW(read_config(invalid_config_path), YAML::ParserException);
+}
+
+TEST_F(ConfigTest, ReadConfigMissingFields) {
+    std::string incomplete_yaml = "base_dir_path: /test/documents\n";
+    std::filesystem::path incomplete_config_path = config_dir_ / "incomplete.yaml";
+    write_yaml_to_file(incomplete_config_path, incomplete_yaml);
+
+    EXPECT_THROW(read_config(incomplete_config_path), YAML::InvalidNode);
+}

--- a/tests/test_fs.cpp
+++ b/tests/test_fs.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include "fs.hpp"
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+class FsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        test_dir = fs::temp_directory_path() / "pdftms_test";
+        fs::create_directories(test_dir);
+        fs::current_path(test_dir);
+
+        test_file = test_dir / "test.pdf";
+        std::ofstream(test_file).put('x');
+
+        test_subdir = test_dir / "subdir";
+        fs::create_directories(test_subdir);
+    }
+
+    void TearDown() override {
+        fs::remove_all(test_dir);
+    }
+
+    fs::path test_dir;
+    fs::path test_file;
+    fs::path test_subdir;
+};
+
+// Tests for get_src_path
+TEST_F(FsTest, GetSrcPathExistingFile) {
+    auto result = get_src_path("test.pdf");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->filename(), "test.pdf");
+}
+
+TEST_F(FsTest, GetSrcPathNonExistentFile) {
+    auto result = get_src_path("nonexistent.pdf");
+    EXPECT_FALSE(result.has_value());
+}
+
+// Tests for get_dest
+TEST_F(FsTest, GetDestExistingDirectory) {
+    auto result = get_dest(test_subdir.string(), true);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, fs::canonical(test_subdir));
+}
+
+TEST_F(FsTest, GetDestNonExistentDirectory) {
+    auto result = get_dest((test_dir / "nonexistent").string(), true);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FsTest, GetDestFileAsDirectory) {
+    auto result = get_dest(test_file.string(), true);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FsTest, GetDestRelativePath) {
+    fs::current_path(test_dir);
+    auto result = get_dest("subdir", true);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, fs::canonical(test_subdir));
+}
+
+// Tests for get_dest_path
+TEST_F(FsTest, GetDestPathValidDirectory) {
+    auto result = get_dest_path(test_subdir.string(), "new.pdf");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->filename(), "new.pdf");
+    EXPECT_EQ(result->parent_path(), fs::canonical(test_subdir));
+}
+
+TEST_F(FsTest, GetDestPathInvalidDirectory) {
+    auto result = get_dest_path((test_dir / "nonexistent").string(), "new.pdf");
+    EXPECT_FALSE(result.has_value());
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+#include "utils.hpp"
+
+#include <cstdlib>
+
+// Save Home and then change it temporarly
+class UtilsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        original_home = std::getenv("HOME");
+        setenv("HOME", "/test/home", 1);
+    }
+
+    void TearDown() override {
+        if (original_home) {
+            setenv("HOME", original_home, 1);
+        } else {
+            unsetenv("HOME");
+        }
+    }
+
+    const char* original_home;
+};
+
+// Tests for expand_tilde
+TEST_F(UtilsTest, ExpandTildeWithHome) {
+    EXPECT_EQ(expand_tilde("~/documents"), "/test/home/documents");
+}
+
+TEST_F(UtilsTest, ExpandTildeWithoutTilde) {
+    EXPECT_EQ(expand_tilde("/usr/local"), "/usr/local");
+}
+
+TEST_F(UtilsTest, ExpandTildeEmpty) {
+    EXPECT_EQ(expand_tilde(""), "");
+}
+
+TEST_F(UtilsTest, ExpandTildeMiddleTilde) {
+    EXPECT_EQ(expand_tilde("/usr/~/local"), "/usr/~/local");
+}
+
+// Tests for rtrim
+TEST(RtrimTest, TrimWhitespace) {
+    EXPECT_EQ(rtrim("hello   "), "hello");
+}
+
+TEST(RtrimTest, TrimTabs) {
+    EXPECT_EQ(rtrim("hello\t\t"), "hello");
+}
+
+TEST(RtrimTest, TrimNewlines) {
+    EXPECT_EQ(rtrim("hello\n\n"), "hello");
+}
+
+TEST(RtrimTest, NoTrim) {
+    EXPECT_EQ(rtrim("hello"), "hello");
+}
+
+TEST(RtrimTest, EmptyString) {
+    EXPECT_EQ(rtrim(""), "");
+}
+
+TEST(RtrimTest, OnlyWhitespace) {
+    EXPECT_EQ(rtrim("   "), "");
+}


### PR DESCRIPTION
Added simple unit tests for `utils.cpp`, `fs.cpp` and `config.cpp`. `fs.cpp` can have more tests, but this will be tiresome and kinda unecessary. The app requires manual testing anyway. 

`CMakeLists.txt` was edited to allow for seamless addition of tests CMakeLists.